### PR TITLE
FIX: enable error-free string output for Python v2 and v3

### DIFF
--- a/diff2HtmlCompare.py
+++ b/diff2HtmlCompare.py
@@ -238,7 +238,12 @@ class DiffHtmlFormatter(HtmlFormatter):
         for t, line in inner:
             if t:
                 lncount += 1
-            dummyoutfile.write(unicode(line))
+
+            # compatibility Python v2/v3
+            if sys.version_info > (3,0):
+                dummyoutfile.write(line)
+            else:
+                dummyoutfile.write(unicode(line))
 
         fl = self.linenostart
         mw = len(str(lncount + fl - 1))


### PR DESCRIPTION
In Python v3.6 there seems to be a problem with ```unicode()```, so (and according to https://stackoverflow.com/questions/6812031/how-to-make-unicode-string-with-python3) a version dependent implementation would do, here.