### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mistune
-pygments
+pygments==2.11


### PR DESCRIPTION
As of 2.12 Pygments requires different arguments to be passed in. To avoid refactoring a bunch of code, just set the latest version of Pygments that still supports your method.